### PR TITLE
Fix Start Menu Cursor Positioning On Init

### DIFF
--- a/src/ui_start_menu.c
+++ b/src/ui_start_menu.c
@@ -638,24 +638,17 @@ static void CursorCallback(struct Sprite *sprite)
 
 static void InitCursorInPlace(void)
 {
-    if (gSelectedMenu >= sStartMenuDataPtr->numVisibleMenuItems)
-        gSelectedMenu = sStartMenuDataPtr->numVisibleMenuItems - 1;
+    if (gSelectedMenu >= TOTAL_MENU_OPTIONS)
+        gSelectedMenu = 0;
 
-    u8 maxVisible = sStartMenuDataPtr->numVisibleMenuItems;
-    if (maxVisible > VISIBLE_BUTTONS)
-        maxVisible = VISIBLE_BUTTONS;
-
-    if (gSavedSelectorY >= maxVisible)
-        gSavedSelectorY = maxVisible - 1;
+    if (gSavedSelectorY >= VISIBLE_BUTTONS)
+        gSavedSelectorY = 0;
 
     int scrollOffsetCandidate = gSelectedMenu - gSavedSelectorY;
     if (scrollOffsetCandidate < 0)
         scrollOffsetCandidate = 0;
-    if (scrollOffsetCandidate > (sStartMenuDataPtr->numVisibleMenuItems - maxVisible))
-        scrollOffsetCandidate = sStartMenuDataPtr->numVisibleMenuItems - maxVisible;
-
-    if (scrollOffsetCandidate < 0)
-        scrollOffsetCandidate = 0;
+    if (scrollOffsetCandidate > TOTAL_MENU_OPTIONS - VISIBLE_BUTTONS)
+        scrollOffsetCandidate = TOTAL_MENU_OPTIONS - VISIBLE_BUTTONS;
 
     sStartMenuDataPtr->scrollOffset = scrollOffsetCandidate;
     sStartMenuDataPtr->selector_y = gSelectedMenu - scrollOffsetCandidate;

--- a/src/ui_start_menu.c
+++ b/src/ui_start_menu.c
@@ -1738,7 +1738,7 @@ static void Task_StartMenu_Main(u8 taskId)
     }
 
     if (gSelectedMenu >= sStartMenuDataPtr->numVisibleMenuItems)
-    gSelectedMenu = sStartMenuDataPtr->numVisibleMenuItems - 1;
+        gSelectedMenu = sStartMenuDataPtr->numVisibleMenuItems - 1;
 
     if (gSavedSelectorY >= min(VISIBLE_BUTTONS, sStartMenuDataPtr->numVisibleMenuItems))
         gSavedSelectorY = min(VISIBLE_BUTTONS, sStartMenuDataPtr->numVisibleMenuItems) - 1;


### PR DESCRIPTION
When the menu is closed and opened, the start menu should not only remember the last saved option, but also the Y position and which entry it was located. This worked properly before #75, but its functionality was broken after that PR. This PR restores it.